### PR TITLE
Fix: user-학생일때, api 오류 수정

### DIFF
--- a/api/src/main/java/com/tikitaka/api/controller/UserController.java
+++ b/api/src/main/java/com/tikitaka/api/controller/UserController.java
@@ -37,7 +37,7 @@ public class UserController {
 
     @Operation(
             summary = "내 포인트 내역 조회",
-            description = "내 포인트 적립/차감 내역을 유형별로 페이징 조회합니다. (예: all, gain, use)"
+            description = "내 포인트 적립/차감 내역을 유형별로 페이징 조회합니다. (TYPE= all,spend,earn)"
     )
     @GetMapping("/points")
     public ResponseEntity<UserPointResponse> getPoints(@AuthenticationPrincipal CustomUserDetails userDetails,

--- a/api/src/main/java/com/tikitaka/api/dto/react/ReactResponse.java
+++ b/api/src/main/java/com/tikitaka/api/dto/react/ReactResponse.java
@@ -7,5 +7,6 @@ public class ReactResponse {
     private String targetType; // like | wonder | medal
     private Long targetId;
     private Long reactCount;
+    private Boolean reacted;
 }
 

--- a/api/src/main/java/com/tikitaka/api/dto/report/ReportRequest.java
+++ b/api/src/main/java/com/tikitaka/api/dto/report/ReportRequest.java
@@ -6,6 +6,5 @@ import lombok.Data;
 public class ReportRequest {
     private String targetType;
     private Long targetId;
-    private Long reasonId;
     private String reason;
 }

--- a/api/src/main/java/com/tikitaka/api/repository/PointTransactionRepository.java
+++ b/api/src/main/java/com/tikitaka/api/repository/PointTransactionRepository.java
@@ -7,9 +7,14 @@ import com.tikitaka.api.domain.point.PointType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 
 public interface PointTransactionRepository extends JpaRepository<PointTransaction, Long> {
-    Long countByUserIdAndType(Long userId, PointType type);
+    @Query("SELECT COALESCE(SUM(p.amount), 0) FROM PointTransaction p WHERE p.user.id = :userId AND p.type = :type")
+    Long sumByUserIdAndType(@Param("userId") Long userId, @Param("type") PointType type);
+
     Page<PointTransaction> findByUserIdAndTypeOrderByCreatedAtDesc(Long userId, PointType type, Pageable pageable);
     Page<PointTransaction> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 }

--- a/api/src/main/java/com/tikitaka/api/repository/ReactRepository.java
+++ b/api/src/main/java/com/tikitaka/api/repository/ReactRepository.java
@@ -3,10 +3,13 @@ package com.tikitaka.api.repository;
 import com.tikitaka.api.domain.question.Question;
 import com.tikitaka.api.domain.react.React;
 import com.tikitaka.api.domain.react.ReactType;
+import com.tikitaka.api.domain.user.User;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 public interface ReactRepository extends JpaRepository<React, Long>{
     Long countByTargetAndType(Question target, ReactType reactType);
@@ -14,4 +17,7 @@ public interface ReactRepository extends JpaRepository<React, Long>{
     Page<React> findByUserId(Long userId, Pageable pageable);
 
     Page<React> findByUserIdAndType(Long userId, ReactType reactType, Pageable pageable);
+
+    Optional<React> findByUserAndTargetAndType(User user, Question target, ReactType type);
+
 }

--- a/api/src/main/java/com/tikitaka/api/service/lecture/LectureServiceImpl.java
+++ b/api/src/main/java/com/tikitaka/api/service/lecture/LectureServiceImpl.java
@@ -142,7 +142,7 @@ public class LectureServiceImpl implements LectureService {
 
             // 메달 유무
             boolean hasMedal = reactRepository.countByTargetAndType(question, ReactType.MEDAL) > 0;
-            dto.setMedal(hasMedal ? "🥇" : null);
+            dto.setMedal(hasMedal ? "🥇" : "0");
 
             return dto;
         }).collect(Collectors.toList());

--- a/api/src/main/java/com/tikitaka/api/service/question/QuestionServiceImpl.java
+++ b/api/src/main/java/com/tikitaka/api/service/question/QuestionServiceImpl.java
@@ -70,7 +70,7 @@ public class QuestionServiceImpl implements QuestionService {
             }
 
             long medalCount = reactRepository.countByTargetAndType(q, ReactType.MEDAL);
-            dto.setMedal(medalCount > 0 ? "gold" : null);
+            dto.setMedal(medalCount > 0 ? "gold" : "0");
 
             return dto;
         }).collect(Collectors.toList());
@@ -89,7 +89,7 @@ public class QuestionServiceImpl implements QuestionService {
         Long likes = reactRepository.countByTargetAndType(question, ReactType.LIKE);
         Long wonder = reactRepository.countByTargetAndType(question, ReactType.WONDER);
         Long medalCount = reactRepository.countByTargetAndType(question, ReactType.MEDAL);
-        String medal = medalCount > 0 ? "gold" : null;
+        String medal = medalCount > 0 ? "gold" : "0";
 
         String questionUserNickname = "티키 " + (question.getUser().getId() % 100 + 1);
 

--- a/api/src/main/java/com/tikitaka/api/service/react/ReactServiceImpl.java
+++ b/api/src/main/java/com/tikitaka/api/service/react/ReactServiceImpl.java
@@ -25,98 +25,53 @@ public class ReactServiceImpl implements ReactService {
     @Override
     @Transactional
     public ReactResponse reactToContent(Long userId, ReactRequest request) {
-        switch (request.getTargetType()) {
-            case "like" -> {
-                return handleLike(userId, request);
-            }
-            case "wonder" -> {
-                return handleWonder(userId, request);
+        return switch (request.getTargetType()) {
+            case "like" -> toggleReact(userId, request, ReactType.LIKE);
+            case "wonder" -> toggleReact(userId, request, ReactType.WONDER);
+            case "medal" -> toggleReact(userId, request, ReactType.MEDAL);
+            default -> throw new IllegalArgumentException("Invalid target type: " + request.getTargetType());
+        };
+    }
 
-            }
-            case "medal" -> {
-                return handleMedal(userId, request);
-            }
-            default -> {
-                throw new IllegalArgumentException("Invalid target type: " + request.getTargetType());
-            }
+    private ReactResponse toggleReact(Long userId, ReactRequest request, ReactType type) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
+
+        Question question = questionRepository.findById(request.getTargetId())
+                .orElseThrow(() -> new RuntimeException("Question not found with id: " + request.getTargetId()));
+
+        // 기존 리액션 여부 확인
+        React existingReact = reactRepository
+                .findByUserAndTargetAndType(user, question, type)
+                .orElse(null);
+
+        boolean reacted;
+
+        if (existingReact != null) {
+            // 이미 눌렀으면 취소
+            reactRepository.delete(existingReact);
+            reacted = false;
+        } else {
+            // 안 눌렀으면 등록
+            React newReact = React.builder()
+                    .user(user)
+                    .target(question)
+                    .type(type)
+                    .build();
+            reactRepository.save(newReact);
+            reacted = true;
         }
-    }
 
-    private ReactResponse handleLike(Long userId, ReactRequest request) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
-        
-        Question question = questionRepository.findById(request.getTargetId())
-                .orElseThrow(() -> new RuntimeException("Question not found with id: " + request.getTargetId()));
-        
+        // 현재 리액션 개수 조회
+        Long count = reactRepository.countByTargetAndType(question, type);
 
-        React react = React.builder()
-                .user(user)
-                .target(question)
-                .type(ReactType.LIKE)
-                .build();
-        
-        reactRepository.save(react);
-        Long count = reactRepository.countByTargetAndType(question, ReactType.LIKE);
+        // 응답 생성
         ReactResponse response = new ReactResponse();
-        response.setTargetType("like");
+        response.setTargetType(type.name().toLowerCase());
         response.setTargetId(request.getTargetId());
         response.setReactCount(count);
+        response.setReacted(reacted); // ✅ 새 필드: 현재 유저가 리액션 눌렀는지 여부
         return response;
     }
-
-
-    private ReactResponse handleWonder(Long userId, ReactRequest request) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
-        
-        Question question = questionRepository.findById(request.getTargetId())
-                .orElseThrow(() -> new RuntimeException("Question not found with id: " + request.getTargetId()));
-
-
-        React react = React.builder()
-                .user(user)
-                .target(question)
-                .type(ReactType.WONDER)
-                .build();
-
-        reactRepository.save(react);
-        
-        Long count = reactRepository.countByTargetAndType(question, ReactType.WONDER);
-
-        ReactResponse response = new ReactResponse();
-        response.setTargetType("wonder");
-        response.setTargetId(request.getTargetId());
-        response.setReactCount(count);
-        return response;     
-        
-    }
-
-
-    private ReactResponse handleMedal(Long userId, ReactRequest request) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
-
-
-        Question question = questionRepository.findById(request.getTargetId())
-                .orElseThrow(() -> new RuntimeException("Question not found with id: " + request.getTargetId()));
-
-        
-        React react = React.builder()
-                .user(user)
-                .target(question)
-                .type(ReactType.MEDAL)
-                .build();
-
-        reactRepository.save(react);
-        
-        Long count = reactRepository.countByTargetAndType(question, ReactType.MEDAL);
-
-        ReactResponse response = new ReactResponse();
-        response.setTargetType("medal");
-        response.setTargetId(request.getTargetId());
-        response.setReactCount(count);
-        return response;
-    }
-    
 }
+

--- a/api/src/main/java/com/tikitaka/api/service/user/UserServiceImpl.java
+++ b/api/src/main/java/com/tikitaka/api/service/user/UserServiceImpl.java
@@ -37,8 +37,8 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
 
-        Long spend = pointTransactionRepository.countByUserIdAndType(userId, PointType.SPEND);
-        Long earn = pointTransactionRepository.countByUserIdAndType(userId, PointType.EARN);
+        Long spend = pointTransactionRepository.sumByUserIdAndType(userId, PointType.SPEND);
+        Long earn = pointTransactionRepository.sumByUserIdAndType(userId, PointType.EARN);
 
         UserInfoResponse.UserDto userDto = new UserInfoResponse.UserDto();
         userDto.setAvatar(user.getAvatarUrl());
@@ -80,8 +80,8 @@ public class UserServiceImpl implements UserService {
 
     public UserPointResponse toUserPointResponse(User user, Page<PointTransaction> transactions) {
         UserPointResponse response = new UserPointResponse();
-        Long earn = pointTransactionRepository.countByUserIdAndType(user.getId(), PointType.EARN);
-        Long spend = pointTransactionRepository.countByUserIdAndType(user.getId(), PointType.SPEND);
+        Long earn = pointTransactionRepository.sumByUserIdAndType(user.getId(), PointType.EARN);
+        Long spend = pointTransactionRepository.sumByUserIdAndType(user.getId(), PointType.SPEND);
         response.setPoint(earn - spend);
 
         Page<UserPointResponse.PointDto> pointDtos = transactions.map(pt -> {


### PR DESCRIPTION
[수정목록]

포인트내역 operation -> type description 잘못 명세
포인트가 내정보조회에 반영 x-> amount 상관없이 1점씩 올라가고 내려가는 부분 -> 포인트 내역대로 반영되게 수정
medal null 값 0으로 수정
좋아요 등록/취소 -> 등록/취소 카운트 처리
질문에 대한 나의 like 확인 (boolean) 가능
신고 등록 할때 요청데이터: reasonId 제외 -> 자동 으로 id 1씩 증가 